### PR TITLE
Fix typos in address comment

### DIFF
--- a/lib/usps/address.rb
+++ b/lib/usps/address.rb
@@ -1,8 +1,8 @@
 # TODO: Documentation
 #
-# The USPS API uses a standard where Address2 is the street adress and Address1 is
+# The USPS API uses a standard where Address2 is the street address and Address1 is
 # the apartment, suite, etc... I have switched them to match how I see them on an envelope.
-# Additionally they are refered to address and extra_address though both address1 and address2
+# Additionally they are referred to address and extra_address though both address1 and address2
 # work. Just remember they are flip flopped based on the USPS documentation.
 class USPS::Address < Struct.new(:name, :company, :address1, :address2, :city, :state, :zip5, :zip4, :return_text, :dpv_confirmation)
 


### PR DESCRIPTION
## Summary
- correct `address` typo in address comments
- correct `referred` typo in address comments

## Testing
- `bundle exec rake spec` *(fails: Could not find gem 'rspec' in locally installed gems)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_683f61b3c074833188404ebb4107dd2c